### PR TITLE
travis: use ssh-keys instead of tokens

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,6 @@ after_success:
 deploy:
   provider: pages                         # Specify the gh-pages deployment method
   skip_cleanup: true                      # Don't remove files
-  github_token: $GITHUB_TOKEN             # Set in travis-ci.org dashboard
   local_dir: docs                         # Deploy the docs folder
   on:
     branch: master


### PR DESCRIPTION
Closes #8 if working.

Did the following:
- `ssh-keygen -f id_rsa`
- `base64 -i id_rsa -o id`
- put `id_rsa.pub` as deploy key on github
- put `id` as the environment variable `id_rsa` on travis