### PR TITLE
Make lintr-bot report on lintr issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,8 @@ before_install:
 after_success:
   - R CMD INSTALL $PKG_TARBALL
   - |
-    if [[ "$TRAVIS_R_VERSION_STRING" == "release" ]] && [[ "$TRAVIS_EVENT_TYPE" == "pull_request" ]]; then
-      Rscript -e 'lintr::lint_package()'
-    fi
     if [[ "$TRAVIS_R_VERSION_STRING" == "release" ]] && [[ "$TRAVIS_EVENT_TYPE" == "push" ]]; then
+      Rscript -e 'lintr::lint_package()'
       Rscript -e 'covr::codecov()'
     fi  
   - rm -rf qmongr.Rcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ services:
 env:
   global:
     - _R_CHECK_TESTS_NLINES_=0
+    - GITHUB_TOKEN=
 
 r_github_packages:
   - jimhester/covr
@@ -38,7 +39,7 @@ deploy:
   # our site to gh_pages
   - provider: pages
     skip_cleanup: true
-    github_token: $GITHUB_TOKEN
+    token: $GH_TOKEN
     keep_history: false
     local_dir: docs
     on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ after_success:
     if [[ "$TRAVIS_R_VERSION_STRING" == "release" ]] && [[ "$TRAVIS_EVENT_TYPE" == "push" ]]; then
       Rscript -e 'lintr::lint_package()'
       Rscript -e 'covr::codecov()'
-    fi  
+    fi
   - rm -rf qmongr.Rcheck
   - Rscript -e 'pkgdown::build_site()'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ services:
 env:
   global:
     - _R_CHECK_TESTS_NLINES_=0
-    - GITHUB_TOKEN=
 
 r_github_packages:
   - jimhester/covr

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,12 @@ before_install:
 after_success:
   - R CMD INSTALL $PKG_TARBALL
   - |
-    if [[ "$TRAVIS_R_VERSION_STRING" == "release" ]]; then
+    if [[ "$TRAVIS_R_VERSION_STRING" == "release" ]] && [[ "$TRAVIS_EVENT_TYPE" == "pull_request" ]]; then
       Rscript -e 'lintr::lint_package()'
-      Rscript -e 'covr::codecov()'
     fi
+    if [[ "$TRAVIS_R_VERSION_STRING" == "release" ]] && [[ "$TRAVIS_EVENT_TYPE" == "push" ]]; then
+      Rscript -e 'covr::codecov()'
+    fi  
   - rm -rf qmongr.Rcheck
   - Rscript -e 'pkgdown::build_site()'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
 after_success:
   - R CMD INSTALL $PKG_TARBALL
   - |
-    if [[ "$TRAVIS_R_VERSION_STRING" == "release" ]] && [[ "TRAVIS_EVENT_TYPE" == "push" ]]; then
+    if [[ "$TRAVIS_R_VERSION_STRING" == "release" ]]; then
       Rscript -e 'lintr::lint_package()'
       Rscript -e 'covr::codecov()'
     fi

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -2,8 +2,8 @@
 #'
 #' @return user interface
 #' @export
-app_ui <- function(){
-  shiny::tagList( 
+app_ui <- function() {
+  shiny::tagList(
     # Leave this function for adding external resources
     qmongr::add_external_resources(),
     # List the first level UI elements here

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -2,8 +2,8 @@
 #'
 #' @return user interface
 #' @export
-app_ui <- function() {
-  shiny::tagList(
+app_ui <- function(){
+  shiny::tagList( 
     # Leave this function for adding external resources
     qmongr::add_external_resources(),
     # List the first level UI elements here


### PR DESCRIPTION
`lintr` is using the global variable `GITHUB_TOKEN`. We can use another name for our use.

Will close #58

Also fixed an error in `.travis.yml` I introduced in #59 (missing `$`).