### PR TITLE
camel_case_linter is deprecated in lintr 2.0

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,2 +1,2 @@
 linters: with_defaults(line_length_linter(120),
-                       camel_case_linter = NULL)
+                       object_name_linter(c("camelCase", "snake_case")))


### PR DESCRIPTION
See https://github.com/jimhester/lintr/releases

With `object_name_linter(c("camelCase", "snake_case"))` we accept both camelCase and snake_case, but not a mix.